### PR TITLE
Add progressive-call feature.

### DIFF
--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1FF3BA6318A5BE1D00EA48AB /* ProgressTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FF3BA6218A5BE1D00EA48AB /* ProgressTaskTests.m */; };
+		1FF3BA6418A5BE1D00EA48AB /* ProgressTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FF3BA6218A5BE1D00EA48AB /* ProgressTaskTests.m */; };
 		8E0B5CD817E139660066379B /* BFTask.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8E9C3D1E17DEA35700427E62 /* BFTask.h */; };
 		8E0B5CD917E1396C0066379B /* BFTaskCompletionSource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8E9C3D2017DEA35700427E62 /* BFTaskCompletionSource.h */; };
 		8E17EC261805D0960049E862 /* Bolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EA6BF661805CED500337041 /* Bolts.m */; };
@@ -105,6 +107,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1FF3BA6218A5BE1D00EA48AB /* ProgressTaskTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProgressTaskTests.m; sourceTree = "<group>"; };
 		8E0B5CDA17E13B4C0066379B /* BoltsVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BoltsVersion.h; sourceTree = "<group>"; };
 		8E8C8ED217F23C3B00E3F1C7 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		8E8C8ED917F23C3B00E3F1C7 /* BoltsTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BoltsTests-Info.plist"; sourceTree = "<group>"; };
@@ -173,6 +176,7 @@
 			children = (
 				8EA6BF681805CF5600337041 /* BoltsTests.m */,
 				8E9C3D1C17DE9F6500427E62 /* TaskTests.m */,
+				1FF3BA6218A5BE1D00EA48AB /* ProgressTaskTests.m */,
 				8E8C8ED817F23C3B00E3F1C7 /* Supporting Files */,
 			);
 			path = BoltsTests;
@@ -380,6 +384,7 @@
 			files = (
 				8EA6BF691805CF5600337041 /* BoltsTests.m in Sources */,
 				8E8C8EFB17F23E5F00E3F1C7 /* TaskTests.m in Sources */,
+				1FF3BA6318A5BE1D00EA48AB /* ProgressTaskTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -389,6 +394,7 @@
 			files = (
 				8E17EC271805D0A40049E862 /* BoltsTests.m in Sources */,
 				8E8C8F2917F241FF00E3F1C7 /* TaskTests.m in Sources */,
+				1FF3BA6418A5BE1D00EA48AB /* ProgressTaskTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bolts/BFTask.h
+++ b/Bolts/BFTask.h
@@ -61,6 +61,11 @@ typedef id(^BFContinuationBlock)(BFTask *task);
 // Properties that will be set on the task once it is completed.
 
 /*!
+ The progress of a task.
+ */
+- (id)progress;
+
+/*!
  The result of a successful task.
  */
 - (id)result;

--- a/Bolts/BFTaskCompletionSource.h
+++ b/Bolts/BFTaskCompletionSource.h
@@ -30,6 +30,11 @@
 @property (nonatomic, retain, readonly) BFTask *task;
 
 /*!
+ Sets progress object to the task.
+ */
+- (void)setProgress:(id)progess;
+
+/*!
  Completes the task by setting the result.
  Attempting to set this for a completed task will raise an exception.
  */

--- a/Bolts/BFTaskCompletionSource.m
+++ b/Bolts/BFTaskCompletionSource.m
@@ -17,10 +17,12 @@
 @end
 
 @interface BFTask (BFTaskCompletionSource)
+- (BOOL)setProgress:(id)progress;
 - (void)setResult:(id)result;
 - (void)setError:(NSError *)error;
 - (void)setException:(NSException *)exception;
 - (void)cancel;
+- (BOOL)trySetProgress:(id)progress;
 - (BOOL)trySetResult:(id)result;
 - (BOOL)trySetError:(NSError *)error;
 - (BOOL)trySetException:(NSException *)exception;
@@ -44,6 +46,10 @@
 
 #pragma mark - Custom Setters/Getters
 
+- (void)setProgress:(id)progress {
+    [self.task setProgress:progress];
+}
+
 - (void)setResult:(id)result {
     [self.task setResult:result];
 }
@@ -58,6 +64,10 @@
 
 - (void)cancel {
     [self.task cancel];
+}
+
+- (BOOL)trySetProgress:(id)progress {
+    return [self.task trySetProgress:progress];
 }
 
 - (BOOL)trySetResult:(id)result {

--- a/BoltsTests/ProgressTaskTests.m
+++ b/BoltsTests/ProgressTaskTests.m
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "Bolts.h"
+
+@interface ProgressTaskTests : XCTestCase
+@end
+
+@implementation ProgressTaskTests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (BFTask*)_progressTask
+{
+    BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
+    
+    for (int i = 1; i <= 10; i++) {
+        double delayInSeconds = 0.2 * i;
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+        dispatch_after(popTime, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+            if (i < 10) {
+                tcs.progress = [NSString stringWithFormat:@"%d%%",i*10]; //@(i/10.0);
+            }
+            else {
+                tcs.result = @"Done";
+            }
+        });
+    }
+    return tcs.task;
+}
+
+- (void)testProgressTask {
+    [[[self _progressTask] continueWithBlock:^id(BFTask *task) {
+        
+        NSLog(@"progress = %@",task.progress);
+        NSLog(@"result = %@",task.result);
+        NSLog(@"\n");
+        
+        XCTAssertTrue(task.progress || task.result);
+        
+        return nil;
+        
+    }] waitUntilFinished];
+}
+
+- (void)testSuccessProgressTask {
+    [[[self _progressTask] continueWithSuccessBlock:^id(BFTask *task) {
+        
+        NSLog(@"progress = %@",task.progress);
+        NSLog(@"result = %@",task.result);
+        NSLog(@"\n");
+        
+        XCTAssertNil(task.progress);
+        XCTAssertEqualObjects(task.result, @"Done");
+        
+        return nil;
+        
+    }] waitUntilFinished];
+}
+
+@end


### PR DESCRIPTION
I added progressive-call feature on BFTask, similar to jQuery's `deferred.progress`/`notify`.
I'm not sure whether I should reuse `-continueWithBlock:` for progress-ibility,
but I will send a sample code anyway.
