### PR TITLE
+[BFTask taskFromExecutor:withBlock] to easily create ad-hoc tasks

### DIFF
--- a/Bolts/BFTask.h
+++ b/Bolts/BFTask.h
@@ -58,6 +58,19 @@ typedef id(^BFContinuationBlock)(BFTask *task);
  */
 + (instancetype)taskWithDelay:(int)millis;
 
+/*!
+ Returns a task that will be completed after the given block completes with
+ the specified executor.
+ @param executor A BFExecutor responsible for determining how the
+ continuation block will be run.
+ @param block The block to immediately schedule to run with the given executor.
+ @returns A task that will be completed after block has run.
+ If block returns a BFTask, then the task returned from
+ this method will not be completed until that task is completed.
+ */
++ (instancetype)taskFromExecutor:(BFExecutor *)executor
+                       withBlock:(id (^)())block;
+
 // Properties that will be set on the task once it is completed.
 
 /*!

--- a/Bolts/BFTask.m
+++ b/Bolts/BFTask.m
@@ -140,6 +140,11 @@ __attribute__ ((noinline)) void warnBlockingOperationOnMainThread() {
     return tcs.task;
 }
 
++ (BFTask *)taskFromExecutor:(BFExecutor *)executor
+                   withBlock:(id (^)())block {
+    return [[self taskWithResult:nil] continueWithExecutor:executor withBlock:block];
+}
+
 #pragma mark - Custom Setters/Getters
 
 - (id)result {

--- a/BoltsTests/TaskTests.m
+++ b/BoltsTests/TaskTests.m
@@ -443,6 +443,18 @@
     XCTAssertEqualObjects(@"foo", task.result);
 }
 
+- (void)testTaskFromExecutor {
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0L);
+    BFExecutor *queueExecutor = [BFExecutor executorWithDispatchQueue:queue];
+
+    BFTask *task = [BFTask taskFromExecutor:queueExecutor withBlock:^id() {
+        XCTAssertEqual(queue, dispatch_get_current_queue());
+        return @"foo";
+    }];
+    [task waitUntilFinished];
+    XCTAssertEqual(@"foo", task.result);
+}
+
 - (void)testExecuteImmediately {
     XCTAssertTrue([NSThread isMainThread]);
     BFTask *task = [BFTask taskWithResult:nil];


### PR DESCRIPTION
This convenience class method makes it easier to create tasks from blocks
without needing to write the code for a temporary `BFTask` or
`BFTaskCompletionSource`. Usage:

```
[[BFTask taskFromExecutor:executor withBlock:id ^{
    return work_on_queue();
}] continueWithBlock:...];
```

As opposed to:

```
BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
dispatch_async(queue, ^{
    [tcs setResult:work_on_queue()];
});
[tcs.task continueWithBlock:...];
```

The convenience method also handles exceptions the same way the rest of BFTasks
does so that's another plus.

Test case is included.
