### PR TITLE
Add no-side-effects version of navigateToAppLink:error: and navigate:

### DIFF
--- a/Bolts/BFAppLinkNavigation.h
+++ b/Bolts/BFAppLinkNavigation.h
@@ -57,6 +57,13 @@ typedef NS_ENUM(NSInteger, BFAppLinkNavigationType) {
                                extras:(NSDictionary *)extras
                           appLinkData:(NSDictionary *)appLinkData;
 
+/*!
+ Creates a NSDictionary with the correct format for iOS callback URLs, to be used
+ as argument 'appLinkData' argument in the call to
+ navigationWithAppLink:extras:appLinkData:
+ */
++ (NSDictionary *)callbackAppLinkDataForAppWithName:(NSString *)appName url:(NSString *)url;
+
 /*! Performs the navigation */
 - (BFAppLinkNavigationType)navigate:(NSError **)error;
 

--- a/Bolts/BFAppLinkNavigation.h
+++ b/Bolts/BFAppLinkNavigation.h
@@ -69,6 +69,21 @@ typedef NS_ENUM(NSInteger, BFAppLinkNavigationType) {
 /*! Navigates to a BFAppLink and returns whether it opened in-app or in-browser */
 + (BFAppLinkNavigationType)navigateToAppLink:(BFAppLink *)link error:(NSError **)error;
 
+/*!
+ Returns a BFAppLinkNavigationType based on a BFAppLink.
+ It's essentially a no-side-effect version of navigateToAppLink:error:,
+ allowing apps to determine flow based on the link type (e.g. open an
+ internal web view instead of going straight to the browser for regular
+ links.)
+ */
++ (BFAppLinkNavigationType)navigationTypeForLink:(BFAppLink *)link;
+
+/*!
+ Return navigation type for current instance.
+ No-side-effect version of navigate:
+ */
+- (BFAppLinkNavigationType)navigationType;
+
 /*! Navigates to a URL (an asynchronous action) and returns a BFNavigationType */
 + (BFTask *)navigateToURLInBackground:(NSURL *)destination;
 

--- a/Bolts/BFAppLinkNavigation.m
+++ b/Bolts/BFAppLinkNavigation.m
@@ -23,6 +23,9 @@ FOUNDATION_EXPORT NSString *const BFAppLinkTargetKeyName;
 FOUNDATION_EXPORT NSString *const BFAppLinkUserAgentKeyName;
 FOUNDATION_EXPORT NSString *const BFAppLinkExtrasKeyName;
 FOUNDATION_EXPORT NSString *const BFAppLinkVersionKeyName;
+FOUNDATION_EXPORT NSString *const BFAppLinkRefererAppLink;
+FOUNDATION_EXPORT NSString *const BFAppLinkRefererAppName;
+FOUNDATION_EXPORT NSString *const BFAppLinkRefererUrl;
 
 static id<BFAppLinkResolving> defaultResolver;
 
@@ -40,6 +43,15 @@ static id<BFAppLinkResolving> defaultResolver;
     navigation->_extras = extras;
     navigation->_appLinkData = appLinkData;
     return navigation;
+}
+
++ (NSDictionary *)callbackAppLinkDataForAppWithName:(NSString *)appName url:(NSString *)url {
+    return @{
+             BFAppLinkRefererAppLink: @{
+                     BFAppLinkRefererAppName: appName,
+                     BFAppLinkRefererUrl: url
+                     }
+             };
 }
 
 - (NSString *)stringByEscapingQueryString:(NSString *)string {

--- a/Bolts/BFAppLinkNavigation.m
+++ b/Bolts/BFAppLinkNavigation.m
@@ -172,6 +172,40 @@ static id<BFAppLinkResolving> defaultResolver;
                                            appLinkData:nil] navigate:error];;
 }
 
++ (BFAppLinkNavigationType)navigationTypeForLink:(BFAppLink *)link {
+    return [[self navigationWithAppLink:link extras:nil appLinkData:nil] navigationType];
+}
+
+- (BFAppLinkNavigationType)navigationType {
+    BFAppLinkTarget *eligibleTarget = nil;
+    for (BFAppLinkTarget *target in self.appLink.targets) {
+        if ([[UIApplication sharedApplication] canOpenURL:target.URL]) {
+            eligibleTarget = target;
+            break;
+        }
+    }
+
+    if (eligibleTarget != nil) {
+        NSURL *appLinkURL = [self appLinkURLWithTargetURL:eligibleTarget.URL error:nil];
+        if (appLinkURL) {
+            return BFAppLinkNavigationTypeApp;
+        } else {
+            return BFAppLinkNavigationTypeFailure;
+        }
+    }
+
+    if (self.appLink.webURL != nil) {
+        NSURL *appLinkURL = [self appLinkURLWithTargetURL:eligibleTarget.URL error:nil];
+        if (appLinkURL) {
+            return BFAppLinkNavigationTypeBrowser;
+        } else {
+            return BFAppLinkNavigationTypeFailure;
+        }
+    }
+
+    return BFAppLinkNavigationTypeFailure;
+}
+
 + (id<BFAppLinkResolving>)defaultResolver {
     if (defaultResolver) {
         return defaultResolver;

--- a/BoltsTests/AppLinkTests.m
+++ b/BoltsTests/AppLinkTests.m
@@ -707,6 +707,19 @@ NSMutableArray *openedUrls = nil;
 
 #pragma mark App link navigation
 
+- (void)testSimpleAppLinkNavigationLookup {
+    BFAppLinkTarget *target = [BFAppLinkTarget appLinkTargetWithURL:[NSURL URLWithString:@"bolts://"]
+                                                         appStoreId:@"12345"
+                                                            appName:@"Bolts"];
+    BFAppLink *appLink = [BFAppLink appLinkWithSourceURL:[NSURL URLWithString:@"http://www.example.com/path"]
+                                                 targets:@[target]
+                                                  webURL:[NSURL URLWithString:@"http://www.example.com/path"]];
+    BFAppLinkNavigationType navigationType = [BFAppLinkNavigation navigationTypeForLink:appLink];
+
+    XCTAssertEqual(navigationType, BFAppLinkNavigationTypeApp);
+    XCTAssertEqual((NSUInteger)0, openedUrls.count); // no side effects
+}
+
 - (void)testSimpleAppLinkNavigation {
     BFAppLinkTarget *target = [BFAppLinkTarget appLinkTargetWithURL:[NSURL URLWithString:@"bolts://"]
                                                          appStoreId:@"12345"


### PR DESCRIPTION
### Summary

- Allows app to know the type of navigation that would result of calling `BFAppLinkNavigation`'s `+navigateToAppLink:error:` or `-navigate:` without having any side effects (i.e. no navigation)
- Also adds a test to ensure same output as `+navigateToAppLink:error:` without the side effects.

### Motivation

Relying on `-navigate:` completely hands off app behavior to Bolts. These no-side-effects functions allow apps to know what behavior Bolts is going to adopt with a given `BFAppLink`.

At Timehop we want to:

- completely hand off behavior if it's an AppLink with eligible targets or;
- use one of our own web views if it's just a regular link or a link that cannot be handled by any installed apps.