### PR TITLE
Bumped pod spec version to 1.1.1

### DIFF
--- a/Bolts.podspec
+++ b/Bolts.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Bolts"
-  s.version      = "1.0.0"
+  s.version      = "1.1.1"
   s.summary      = "Bolts is a collection of low-level libraries designed to make developing mobile apps easier."
   s.description  = <<-DESC
                     Bolts was designed by Parse and Facebook for our own internal use, and we have decided to open source these libraries to make them available to others. Using these libraries does not require using any Parse services. Nor do they require having a Parse or Facebook developer account.


### PR DESCRIPTION
Several bugs have been fixed since the `1.1.0` release on CocoaPods. In particular, `1.1.0` has two compiler warnings due to checking for `respondsToSelector` on non-existent method signatures.

Please tag the latest `master` commit as `1.1.1`, merge this change into the main repo, and <a href="http://guides.cocoapods.org/making/getting-setup-with-trunk.html">push to trunk</a>.
