### PR TITLE
Added sample app to demonstrate usage of BFAppLinkReturnToRefererController

### DIFF
--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -79,6 +79,13 @@
 		8EA6BF691805CF5600337041 /* BoltsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EA6BF681805CF5600337041 /* BoltsTests.m */; };
 		8EDDA63017E17DDC00655F8A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
 		B242FABB19A567660097ECAE /* BFMeasurementEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = B242FAB919A567660097ECAE /* BFMeasurementEvent.m */; };
+		E11219DB1B8CEF8700880395 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E11219DA1B8CEF8700880395 /* main.m */; };
+		E11219DE1B8CEF8700880395 /* SampleAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E11219DD1B8CEF8700880395 /* SampleAppDelegate.m */; };
+		E11219E61B8CEF8700880395 /* SampleAppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E11219E51B8CEF8700880395 /* SampleAppImages.xcassets */; };
+		E1BC73411B8CF04100D4B695 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E1BC733E1B8CF04100D4B695 /* InfoPlist.strings */; };
+		E1BDB01A1B8CF5E6002A3914 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDDA63517E17DDD00655F8A /* Bolts.framework */; };
+		E1BDB01E1B8CF9F5002A3914 /* SampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E1BDB01C1B8CF9F5002A3914 /* SampleViewController.m */; };
+		E1BDB01F1B8CF9F5002A3914 /* SampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E1BDB01D1B8CF9F5002A3914 /* SampleViewController.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,6 +109,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8EDDA62817E17DDC00655F8A;
 			remoteInfo = MacBolts;
+		};
+		E1BDB0181B8CF5C4002A3914 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8E9C3CE117DE9DE000427E62 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8E9C3CE817DE9DE000427E62;
+			remoteInfo = Bolts;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -174,6 +188,17 @@
 		B242FAB919A567660097ECAE /* BFMeasurementEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BFMeasurementEvent.m; sourceTree = "<group>"; };
 		B242FABA19A567660097ECAE /* BFURL_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BFURL_Internal.h; sourceTree = "<group>"; };
 		B242FAC019A599CD0097ECAE /* BFMeasurementEvent_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BFMeasurementEvent_Internal.h; sourceTree = "<group>"; };
+		E11219D61B8CEF8700880395 /* BoltsSampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoltsSampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E11219DA1B8CEF8700880395 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		E11219DC1B8CEF8700880395 /* SampleAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SampleAppDelegate.h; sourceTree = "<group>"; };
+		E11219DD1B8CEF8700880395 /* SampleAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SampleAppDelegate.m; sourceTree = "<group>"; };
+		E11219E51B8CEF8700880395 /* SampleAppImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = SampleAppImages.xcassets; sourceTree = "<group>"; };
+		E1BC733C1B8CF04100D4B695 /* BoltsSampleApp-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "BoltsSampleApp-Info.plist"; sourceTree = "<group>"; };
+		E1BC733D1B8CF04100D4B695 /* BoltsSampleApp-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BoltsSampleApp-Prefix.pch"; sourceTree = "<group>"; };
+		E1BC733F1B8CF04100D4B695 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E1BDB01B1B8CF9F5002A3914 /* SampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SampleViewController.h; sourceTree = "<group>"; };
+		E1BDB01C1B8CF9F5002A3914 /* SampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SampleViewController.m; sourceTree = "<group>"; };
+		E1BDB01D1B8CF9F5002A3914 /* SampleViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SampleViewController.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -219,6 +244,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				8EDDA63017E17DDC00655F8A /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E11219D31B8CEF8700880395 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1BDB01A1B8CF5E6002A3914 /* Bolts.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -328,6 +361,7 @@
 				8E9C3CEE17DE9DE000427E62 /* Bolts */,
 				8E8C8ED717F23C3B00E3F1C7 /* BoltsTests */,
 				1EC3016618CDAA8400D06D07 /* BoltsTestUI */,
+				E11219D71B8CEF8700880395 /* BoltsSampleApp */,
 				8E9C3CEB17DE9DE000427E62 /* Frameworks */,
 				8E9C3CEA17DE9DE000427E62 /* Products */,
 			);
@@ -343,6 +377,7 @@
 				8E8C8EE917F23D1D00E3F1C7 /* BoltsTests.xctest */,
 				8E8C8F1917F241DA00E3F1C7 /* MacBoltsTests.xctest */,
 				1EC3016018CDAA8400D06D07 /* BoltsTestUI.app */,
+				E11219D61B8CEF8700880395 /* BoltsSampleApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -377,6 +412,31 @@
 				8122B2881AA0E8220025C5AF /* iOS-Info.plist */,
 				81F0E88D19E5CB5A00812A88 /* Mac-Info.plist */,
 				8E9C3CF017DE9DE000427E62 /* Bolts-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E11219D71B8CEF8700880395 /* BoltsSampleApp */ = {
+			isa = PBXGroup;
+			children = (
+				E11219DC1B8CEF8700880395 /* SampleAppDelegate.h */,
+				E11219DD1B8CEF8700880395 /* SampleAppDelegate.m */,
+				E1BDB01B1B8CF9F5002A3914 /* SampleViewController.h */,
+				E1BDB01C1B8CF9F5002A3914 /* SampleViewController.m */,
+				E1BDB01D1B8CF9F5002A3914 /* SampleViewController.xib */,
+				E11219E51B8CEF8700880395 /* SampleAppImages.xcassets */,
+				E11219D81B8CEF8700880395 /* Supporting Files */,
+			);
+			path = BoltsSampleApp;
+			sourceTree = "<group>";
+		};
+		E11219D81B8CEF8700880395 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E1BC733C1B8CF04100D4B695 /* BoltsSampleApp-Info.plist */,
+				E1BC733E1B8CF04100D4B695 /* InfoPlist.strings */,
+				E11219DA1B8CEF8700880395 /* main.m */,
+				E1BC733D1B8CF04100D4B695 /* BoltsSampleApp-Prefix.pch */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -514,6 +574,24 @@
 			productReference = 8EDDA63517E17DDD00655F8A /* Bolts.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		E11219D51B8CEF8700880395 /* BoltsSampleApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E11219FA1B8CEF8700880395 /* Build configuration list for PBXNativeTarget "BoltsSampleApp" */;
+			buildPhases = (
+				E11219D21B8CEF8700880395 /* Sources */,
+				E11219D31B8CEF8700880395 /* Frameworks */,
+				E11219D41B8CEF8700880395 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E1BDB0191B8CF5C4002A3914 /* PBXTargetDependency */,
+			);
+			name = BoltsSampleApp;
+			productName = BoltsSampleApp;
+			productReference = E11219D61B8CEF8700880395 /* BoltsSampleApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -548,6 +626,7 @@
 				8E8C8EE817F23D1D00E3F1C7 /* BoltsTests */,
 				8E8C8F1817F241DA00E3F1C7 /* MacBoltsTests */,
 				1EC3015F18CDAA8300D06D07 /* BoltsTestUI */,
+				E11219D51B8CEF8700880395 /* BoltsSampleApp */,
 			);
 		};
 /* End PBXProject section */
@@ -574,6 +653,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E11219D41B8CEF8700880395 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E11219E61B8CEF8700880395 /* SampleAppImages.xcassets in Resources */,
+				E1BDB01F1B8CF9F5002A3914 /* SampleViewController.xib in Resources */,
+				E1BC73411B8CF04100D4B695 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -649,6 +738,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E11219D21B8CEF8700880395 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E11219DE1B8CEF8700880395 /* SampleAppDelegate.m in Sources */,
+				E11219DB1B8CEF8700880395 /* main.m in Sources */,
+				E1BDB01E1B8CF9F5002A3914 /* SampleViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -666,6 +765,11 @@
 			isa = PBXTargetDependency;
 			target = 8EDDA62817E17DDC00655F8A /* MacBolts */;
 			targetProxy = 8E8C8F2417F241DA00E3F1C7 /* PBXContainerItemProxy */;
+		};
+		E1BDB0191B8CF5C4002A3914 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8E9C3CE817DE9DE000427E62 /* Bolts */;
+			targetProxy = E1BDB0181B8CF5C4002A3914 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -690,6 +794,14 @@
 			isa = PBXVariantGroup;
 			children = (
 				8E8C8EDB17F23C3B00E3F1C7 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		E1BC733E1B8CF04100D4B695 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E1BC733F1B8CF04100D4B695 /* en */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -1032,6 +1144,75 @@
 			};
 			name = Release;
 		};
+		E11219F61B8CEF8700880395 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BoltsSampleApp/BoltsSampleApp-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "BoltsSampleApp/BoltsSampleApp-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[arch=arm64]" = 6.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		E11219F71B8CEF8700880395 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BoltsSampleApp/BoltsSampleApp-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "BoltsSampleApp/BoltsSampleApp-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[arch=arm64]" = 6.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1085,6 +1266,15 @@
 			buildConfigurations = (
 				8EDDA63317E17DDC00655F8A /* Debug */,
 				8EDDA63417E17DDC00655F8A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E11219FA1B8CEF8700880395 /* Build configuration list for PBXNativeTarget "BoltsSampleApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E11219F61B8CEF8700880395 /* Debug */,
+				E11219F71B8CEF8700880395 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BoltsSampleApp/BoltsSampleApp-Info.plist
+++ b/BoltsSampleApp/BoltsSampleApp-Info.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>bolts.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>boltssample</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+</dict>
+</plist>

--- a/BoltsSampleApp/BoltsSampleApp-Prefix.pch
+++ b/BoltsSampleApp/BoltsSampleApp-Prefix.pch
@@ -1,0 +1,16 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#import <Availability.h>
+
+#ifndef __IPHONE_3_0
+#warning "This project uses features only available in iOS SDK 3.0 and later."
+#endif
+
+#ifdef __OBJC__
+    #import <UIKit/UIKit.h>
+    #import <Foundation/Foundation.h>
+#endif

--- a/BoltsSampleApp/SampleAppDelegate.h
+++ b/BoltsSampleApp/SampleAppDelegate.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+@class BFURL;
+
+extern NSString *const BFSampleURLWithRefererData;
+
+@interface SampleAppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@property (strong, nonatomic) BFURL *receivedAppLinkURL;
+
++ (instancetype)sharedInstance;
+
+@end
+

--- a/BoltsSampleApp/SampleAppDelegate.m
+++ b/BoltsSampleApp/SampleAppDelegate.m
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "SampleAppDelegate.h"
+#import "SampleViewController.h"
+#import <Bolts/Bolts.h>
+
+NSString *const BFSampleURLWithRefererData = @"boltssample://?foo=bar&al_applink_data=%7B%22a%22%3A%22b%22%2C%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3A%22http%3A%5C%2F%5C%2Fwww.example.com%5C%2Fpath%3Fbaz%3Dbat%22%2C%22referer_app_link%22%3A%7B%22app_name%22%3A%22Facebook%22%2C%22url%22%3A%22fb%3A%5C%2F%5C%2Fsomething%5C%2F%22%7D%7D";
+
+@implementation SampleAppDelegate
+
+#pragma mark - Sample Implementation
+
++ (instancetype)sharedInstance {
+    return [[UIApplication sharedApplication] delegate];
+}
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication
+         annotation:(id)annotation {
+    self.receivedAppLinkURL = [BFURL URLWithURL:url];
+    // Handle the app link here
+    return YES;
+}
+
+#pragma mark - Setup for Sample App
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+    [self.window makeKeyAndVisible];
+    [self.window setRootViewController:[[SampleViewController alloc] init]];
+    return YES;
+}
+
+@end

--- a/BoltsSampleApp/SampleAppImages.xcassets/AppIcon.appiconset/Contents.json
+++ b/BoltsSampleApp/SampleAppImages.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/BoltsSampleApp/SampleAppImages.xcassets/LaunchImage.launchimage/Contents.json
+++ b/BoltsSampleApp/SampleAppImages.xcassets/LaunchImage.launchimage/Contents.json
@@ -1,0 +1,142 @@
+{
+  "images" : [
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "8.0",
+      "subtype" : "736h",
+      "scale" : "3x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "8.0",
+      "subtype" : "736h",
+      "scale" : "3x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "8.0",
+      "subtype" : "667h",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "subtype" : "retina4",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "1x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "1x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "scale" : "1x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "subtype" : "retina4",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "ipad",
+      "extent" : "to-status-bar",
+      "scale" : "1x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "scale" : "1x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "ipad",
+      "extent" : "to-status-bar",
+      "scale" : "1x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "scale" : "1x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "ipad",
+      "extent" : "to-status-bar",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "ipad",
+      "extent" : "to-status-bar",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/BoltsSampleApp/SampleViewController.h
+++ b/BoltsSampleApp/SampleViewController.h
@@ -1,0 +1,13 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+@interface SampleViewController : UIViewController
+
+@end

--- a/BoltsSampleApp/SampleViewController.m
+++ b/BoltsSampleApp/SampleViewController.m
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "SampleViewController.h"
+#import "SampleAppDelegate.h"
+#import <Bolts/Bolts.h>
+
+static void *kReceivedAppLinkURLObserverContext = &kReceivedAppLinkURLObserverContext;
+static void *kReturnToRefererViewClosedObserverContext = &kReturnToRefererViewClosedObserverContext;
+
+@interface SampleViewController () <BFAppLinkReturnToRefererControllerDelegate>
+
+@property (nonatomic, strong) BFAppLinkReturnToRefererController *returnToRefererController;
+
+@end
+
+@implementation SampleViewController
+
+#pragma mark - Sample Implementation
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self toggleRefererBackButtonIfNeeded];
+    [[SampleAppDelegate sharedInstance] addObserver:self
+                                         forKeyPath:@"receivedAppLinkURL"
+                                            options:0
+                                            context:kReceivedAppLinkURLObserverContext];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self toggleRefererBackButtonIfNeeded];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    [[SampleAppDelegate sharedInstance] removeObserver:self
+                                            forKeyPath:@"receivedAppLinkURL"
+                                               context:kReceivedAppLinkURLObserverContext];
+}
+
+// Best called at -viewWillAppear, -viewDidAppear and when receivedAppLinkURL changes.
+- (void)toggleRefererBackButtonIfNeeded {
+    // Provide the received AppLink (NSURL) in your app delegate
+    BFURL *receivedAppLinkURL = [SampleAppDelegate sharedInstance].receivedAppLinkURL;
+    if (receivedAppLinkURL.appLinkReferer != nil) {
+        // If you want to display the BFAppLinkReturnToRefererController and its view
+        // in a non-UINavigationController, you need to add the view to your main view
+        // and manage its position/frame yourself.
+        if (self.returnToRefererController == nil && self.navigationController != nil) {
+            self.returnToRefererController = [[BFAppLinkReturnToRefererController alloc] initForDisplayAboveNavController:self.navigationController];
+
+            // You can set a custom BFAppLinkReturnToRefererView:
+            // self.returnToRefererController.view = [MyCustomSubclassOfBFAppLinkReturnToRefererView new];
+            self.returnToRefererController.view.frame = CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 1);
+            self.returnToRefererController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+
+            // When the user taps the back link or the close button of the BFAppLinkReturnToRefererView,
+            // you need to reset the receivedAppLinkURL, so all BFAppLinkReturnToRefererController can
+            // remove themselves. So, observe the "closed" state of the view:
+            [self.returnToRefererController.view addObserver:self
+                                                  forKeyPath:@"closed"
+                                                     options:0
+                                                     context:kReturnToRefererViewClosedObserverContext];
+        }
+        [self.returnToRefererController showViewForRefererAppLink:receivedAppLinkURL.appLinkReferer];
+
+    } else if (self.returnToRefererController != nil) {
+        [self.returnToRefererController.view removeObserver:self
+                                                 forKeyPath:@"closed"
+                                                    context:kReturnToRefererViewClosedObserverContext];
+        [self.returnToRefererController removeFromNavController];
+        self.returnToRefererController = nil;
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+    if (context == kReceivedAppLinkURLObserverContext) {
+        // Whenever the receivedAppLinkURL changes, check if the
+        // BFAppLinkReturnToRefererView needs to be toggled.
+        [self toggleRefererBackButtonIfNeeded];
+
+    } else if (context == kReturnToRefererViewClosedObserverContext) {
+        // When the view was closed, reset the receivedAppLinkURL,
+        // so all BFAppLinkReturnToRefererController can remove themselves.
+        if (self.returnToRefererController.view.closed) {
+            [SampleAppDelegate sharedInstance].receivedAppLinkURL = nil;
+            // This will trigger -observeValueForKeyPath
+            // for all objects listening to receivedAppLinkURL.
+        }
+    } else {
+        [super observeValueForKeyPath:keyPath
+                             ofObject:object
+                               change:change
+                              context:context];
+    }
+}
+
+#pragma mark - Interface Events of the Sample App
+
+- (IBAction)appLinkButtonTapped:(UIButton *)button {
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:BFSampleURLWithRefererData]];
+}
+
+- (IBAction)flipButtonTapped:(UIButton *)button {
+    if (self.presentingViewController != nil && self.navigationController == nil) {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    } else {
+        SampleViewController *viewController = [[SampleViewController alloc] init];
+        viewController.modalTransitionStyle = UIModalTransitionStyleFlipHorizontal;
+        [self presentViewController:viewController animated:YES completion:nil];
+    }
+}
+
+- (IBAction)modalButtonTapped:(UIButton *)button {
+    UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                                                                                target:self
+                                                                                action:@selector(doneButtonTapped:)];
+    SampleViewController *viewController = [[SampleViewController alloc] init];
+    viewController.navigationItem.leftBarButtonItem = doneButton;
+
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+    navigationController.navigationBar.translucent = NO;
+
+    [self presentViewController:navigationController animated:YES completion:nil];
+}
+
+- (void)doneButtonTapped:(UIButton *)button {
+    [self.presentedViewController dismissViewControllerAnimated:YES completion:nil];
+}
+
+@end

--- a/BoltsSampleApp/SampleViewController.xib
+++ b/BoltsSampleApp/SampleViewController.xib
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" variant="6xAndEarlier" propertyAccessControl="none">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="20" width="320" height="548"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Igs-Tn-XeW">
+                    <rect key="frame" x="55" y="201" width="210" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Invoke app link"/>
+                    <connections>
+                        <action selector="appLinkButtonTapped:" destination="-2" eventType="touchUpInside" id="Mc8-VU-v74"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="bdD-79-eix">
+                    <rect key="frame" x="55" y="252" width="210" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Flip modal"/>
+                    <connections>
+                        <action selector="flipButtonTapped:" destination="-2" eventType="touchUpInside" id="Pp2-Bq-An5"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="5fA-An-dik">
+                    <rect key="frame" x="55" y="303" width="210" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Open navigation controller"/>
+                    <connections>
+                        <action selector="modalButtonTapped:" destination="-2" eventType="touchUpInside" id="YmC-9L-0CH"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <point key="canvasLocation" x="266" y="333"/>
+        </view>
+    </objects>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/BoltsSampleApp/en.lproj/InfoPlist.strings
+++ b/BoltsSampleApp/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/BoltsSampleApp/main.m
+++ b/BoltsSampleApp/main.m
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "SampleAppDelegate.h"
+
+int main(int argc, char * argv[])
+{
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([SampleAppDelegate class]));
+    }
+}


### PR DESCRIPTION
The sample app demonstrates how to implement the `BFAppLinkReturnToRefererController` in your own app. It explains the following common issues:
- How to provide the received app link URL (`BFURL`) app-wide.
- How to trigger the display of the return button in the current view controller and all preceding or following view controllers.
- How to configure the view that it behaves correctly after changed device orientation.
- How to automatically remove the return button on all view controllers in the current stack when the button isn't needed any more.