### PR TITLE
Fixed issue 192

### DIFF
--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0937F9431BE577F1008C38BA /* BFAppLinkNavigationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0937F9401BE576BE008C38BA /* BFAppLinkNavigationType.h */; };
-		0937F9441BE577F1008C38BA /* BFAppLinkReturnToRefererViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0937F93F1BE575FF008C38BA /* BFAppLinkReturnToRefererViewDelegate.h */; };
+		0937F9431BE577F1008C38BA /* BFAppLinkNavigationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0937F9401BE576BE008C38BA /* BFAppLinkNavigationType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0937F9441BE577F1008C38BA /* BFAppLinkReturnToRefererViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0937F93F1BE575FF008C38BA /* BFAppLinkReturnToRefererViewDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1E9BF8DC18EA0CAD00514B1E /* test.html in Resources */ = {isa = PBXBuildFile; fileRef = 1E9BF8DB18EA0CAD00514B1E /* test.html */; };
 		1EC3016118CDAA8400D06D07 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
 		1EC3016318CDAA8400D06D07 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EC3016218CDAA8400D06D07 /* CoreGraphics.framework */; };
@@ -584,6 +584,7 @@
 				81ED941D1BE147CF00795F05 /* BFCancellationTokenRegistration.h in Headers */,
 				81ED941E1BE147CF00795F05 /* BFTask.h in Headers */,
 				81ED942E1BE1481900795F05 /* BFAppLinkNavigation.h in Headers */,
+				0937F9431BE577F1008C38BA /* BFAppLinkNavigationType.h in Headers */,
 				81ED94351BE1481900795F05 /* BFAppLinkReturnToRefererView.h in Headers */,
 				81ED941F1BE147CF00795F05 /* BFCancellationTokenSource.h in Headers */,
 				81ED94201BE147CF00795F05 /* BFExecutor.h in Headers */,
@@ -598,7 +599,6 @@
 				81ED943A1BE1481900795F05 /* BFMeasurementEvent_Internal.h in Headers */,
 				81ED943B1BE1481900795F05 /* BFMeasurementEvent.h in Headers */,
 				81ED942B1BE1481900795F05 /* BFAppLink_Internal.h in Headers */,
-				0937F9431BE577F1008C38BA /* BFAppLinkNavigationType.h in Headers */,
 				0937F9441BE577F1008C38BA /* BFAppLinkReturnToRefererViewDelegate.h in Headers */,
 				81ED94241BE147CF00795F05 /* Bolts.h in Headers */,
 				81ED94251BE147CF00795F05 /* BFCancellationToken.h in Headers */,

--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0937F9431BE577F1008C38BA /* BFAppLinkNavigationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0937F9401BE576BE008C38BA /* BFAppLinkNavigationType.h */; };
+		0937F9441BE577F1008C38BA /* BFAppLinkReturnToRefererViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0937F93F1BE575FF008C38BA /* BFAppLinkReturnToRefererViewDelegate.h */; };
 		1E9BF8DC18EA0CAD00514B1E /* test.html in Resources */ = {isa = PBXBuildFile; fileRef = 1E9BF8DB18EA0CAD00514B1E /* test.html */; };
 		1EC3016118CDAA8400D06D07 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
 		1EC3016318CDAA8400D06D07 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EC3016218CDAA8400D06D07 /* CoreGraphics.framework */; };
@@ -155,6 +157,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0937F93F1BE575FF008C38BA /* BFAppLinkReturnToRefererViewDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BFAppLinkReturnToRefererViewDelegate.h; sourceTree = "<group>"; };
+		0937F9401BE576BE008C38BA /* BFAppLinkNavigationType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BFAppLinkNavigationType.h; sourceTree = "<group>"; };
 		1E9BF8DB18EA0CAD00514B1E /* test.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = test.html; sourceTree = "<group>"; };
 		1EC3016018CDAA8400D06D07 /* BoltsTestUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoltsTestUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1EC3016218CDAA8400D06D07 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -371,6 +375,7 @@
 				8103FA5A19900A84000BAE3F /* BFAppLinkNavigation.h */,
 				8103FA5B19900A84000BAE3F /* BFAppLinkNavigation.m */,
 				8103FA5C19900A84000BAE3F /* BFAppLinkResolving.h */,
+				0937F9401BE576BE008C38BA /* BFAppLinkNavigationType.h */,
 				8103FA6619900A84000BAE3F /* BFWebViewAppLinkResolver.h */,
 				8103FA6719900A84000BAE3F /* BFWebViewAppLinkResolver.m */,
 				8103FA5D19900A84000BAE3F /* BFAppLinkReturnToRefererController.h */,
@@ -378,6 +383,7 @@
 				8103FA5F19900A84000BAE3F /* BFAppLinkReturnToRefererView.h */,
 				8103FA6019900A84000BAE3F /* BFAppLinkReturnToRefererView.m */,
 				8103FA6119900A84000BAE3F /* BFAppLinkReturnToRefererView_Internal.h */,
+				0937F93F1BE575FF008C38BA /* BFAppLinkReturnToRefererViewDelegate.h */,
 				8103FA6219900A84000BAE3F /* BFAppLinkTarget.h */,
 				8103FA6319900A84000BAE3F /* BFAppLinkTarget.m */,
 				B242FAC019A599CD0097ECAE /* BFMeasurementEvent_Internal.h */,
@@ -592,6 +598,8 @@
 				81ED943A1BE1481900795F05 /* BFMeasurementEvent_Internal.h in Headers */,
 				81ED943B1BE1481900795F05 /* BFMeasurementEvent.h in Headers */,
 				81ED942B1BE1481900795F05 /* BFAppLink_Internal.h in Headers */,
+				0937F9431BE577F1008C38BA /* BFAppLinkNavigationType.h in Headers */,
+				0937F9441BE577F1008C38BA /* BFAppLinkReturnToRefererViewDelegate.h in Headers */,
 				81ED94241BE147CF00795F05 /* Bolts.h in Headers */,
 				81ED94251BE147CF00795F05 /* BFCancellationToken.h in Headers */,
 				81ED942C1BE1481900795F05 /* BFAppLink.h in Headers */,

--- a/Bolts/Common/BFCancellationToken.h
+++ b/Bolts/Common/BFCancellationToken.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFCancellationTokenRegistration.h>
+@class BFCancellationTokenRegistration;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bolts/Common/Bolts.h
+++ b/Bolts/Common/Bolts.h
@@ -8,7 +8,6 @@
  *
  */
 
-#import <Bolts/BoltsVersion.h>
 #import <Bolts/BFCancellationToken.h>
 #import <Bolts/BFCancellationTokenRegistration.h>
 #import <Bolts/BFCancellationTokenSource.h>

--- a/Bolts/Common/Bolts.m
+++ b/Bolts/Common/Bolts.m
@@ -9,6 +9,7 @@
  */
 
 #import "Bolts.h"
+#import "BoltsVersion.h"
 
 NSInteger const kBFMultipleErrorsError = 80175001;
 

--- a/Bolts/iOS/BFAppLinkNavigation.h
+++ b/Bolts/iOS/BFAppLinkNavigation.h
@@ -9,20 +9,8 @@
  */
 
 #import <Foundation/Foundation.h>
-
 #import <Bolts/BFAppLink.h>
-
-/*!
- The result of calling navigate on a BFAppLinkNavigation
- */
-typedef NS_ENUM(NSInteger, BFAppLinkNavigationType) {
-    /*! Indicates that the navigation failed and no app was opened */
-    BFAppLinkNavigationTypeFailure,
-    /*! Indicates that the navigation succeeded by opening the URL in the browser */
-    BFAppLinkNavigationTypeBrowser,
-    /*! Indicates that the navigation succeeded by opening the URL in an app on the device */
-    BFAppLinkNavigationTypeApp
-};
+#import <Bolts/BFAppLinkNavigationType.h>
 
 @protocol BFAppLinkResolving;
 @class BFTask;

--- a/Bolts/iOS/BFAppLinkNavigationType.h
+++ b/Bolts/iOS/BFAppLinkNavigationType.h
@@ -1,0 +1,19 @@
+//
+//  BFAppLinkNavigationType.h
+//  Bolts
+//
+//  Created by Marcel Bradea on 2015-10-31.
+//  Copyright © 2015 Parse Inc. All rights reserved.
+//
+
+/*!
+ The result of calling navigate on a BFAppLinkNavigation
+ */
+typedef NS_ENUM(NSInteger, BFAppLinkNavigationType) {
+    /*! Indicates that the navigation failed and no app was opened */
+    BFAppLinkNavigationTypeFailure,
+    /*! Indicates that the navigation succeeded by opening the URL in the browser */
+    BFAppLinkNavigationTypeBrowser,
+    /*! Indicates that the navigation succeeded by opening the URL in an app on the device */
+    BFAppLinkNavigationTypeApp
+};

--- a/Bolts/iOS/BFAppLinkReturnToRefererController.h
+++ b/Bolts/iOS/BFAppLinkReturnToRefererController.h
@@ -10,9 +10,10 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <Bolts/BFAppLinkReturnToRefererViewDelegate.h>
+#import <Bolts/BFAppLinkNavigationType.h>
 
-#import <Bolts/BFAppLinkReturnToRefererView.h>
-
+@class BFAppLinkReturnToRefererView;
 @class BFAppLink;
 @class BFAppLinkReturnToRefererController;
 

--- a/Bolts/iOS/BFAppLinkReturnToRefererController.m
+++ b/Bolts/iOS/BFAppLinkReturnToRefererController.m
@@ -9,7 +9,7 @@
  */
 
 #import "BFAppLinkReturnToRefererController.h"
-
+#import "BFAppLinkReturnToRefererView.h"
 #import "BFAppLink.h"
 #import "BFAppLinkReturnToRefererView_Internal.h"
 #import "BFURL_Internal.h"

--- a/Bolts/iOS/BFAppLinkReturnToRefererView.h
+++ b/Bolts/iOS/BFAppLinkReturnToRefererView.h
@@ -13,6 +13,8 @@
 
 #import <Bolts/BFAppLinkNavigation.h>
 
+#import "BFAppLinkReturnToRefererViewDelegate.h"
+
 @class BFAppLinkReturnToRefererView;
 @class BFURL;
 
@@ -21,25 +23,6 @@ typedef NS_ENUM(NSUInteger, BFIncludeStatusBarInSize) {
     BFIncludeStatusBarInSizeIOS7AndLater,
     BFIncludeStatusBarInSizeAlways,
 };
-
-/*!
- Protocol that a class can implement in order to be notified when the user has navigated back
- to the referer of an App Link.
- */
-@protocol BFAppLinkReturnToRefererViewDelegate <NSObject>
-
-/*!
- Called when the user has tapped inside the close button.
- */
-- (void)returnToRefererViewDidTapInsideCloseButton:(BFAppLinkReturnToRefererView *)view;
-
-/*!
- Called when the user has tapped inside the App Link portion of the view.
- */
-- (void)returnToRefererViewDidTapInsideLink:(BFAppLinkReturnToRefererView *)view
-                                       link:(BFAppLink *)link;
-
-@end
 
 /*!
  Provides a UIView that displays a button allowing users to navigate back to the

--- a/Bolts/iOS/BFAppLinkReturnToRefererViewDelegate.h
+++ b/Bolts/iOS/BFAppLinkReturnToRefererViewDelegate.h
@@ -1,0 +1,29 @@
+//
+//  BFAppLinkReturnToRefererViewDelegate.h
+//  Bolts
+//
+//  Created by Marcel Bradea on 2015-10-31.
+//  Copyright © 2015 Parse Inc. All rights reserved.
+//
+
+@class BFAppLinkReturnToRefererView;
+@class BFAppLink;
+
+/*!
+ Protocol that a class can implement in order to be notified when the user has navigated back
+ to the referer of an App Link.
+ */
+@protocol BFAppLinkReturnToRefererViewDelegate <NSObject>
+
+/*!
+ Called when the user has tapped inside the close button.
+ */
+- (void)returnToRefererViewDidTapInsideCloseButton:(BFAppLinkReturnToRefererView *)view;
+
+/*!
+ Called when the user has tapped inside the App Link portion of the view.
+ */
+- (void)returnToRefererViewDidTapInsideLink:(BFAppLinkReturnToRefererView *)view
+                                       link:(BFAppLink *)link;
+
+@end

--- a/BoltsTests/BoltsTests.m
+++ b/BoltsTests/BoltsTests.m
@@ -11,6 +11,8 @@
 @import XCTest;
 
 #import <Bolts/Bolts.h>
+#import <Bolts/BoltsVersion.h>
+
 
 @interface BoltsTests : XCTestCase
 @end


### PR DESCRIPTION
Fixed issue 192 (https://github.com/BoltsFramework/Bolts-iOS/issues/192), allowing projects that include frameworks which themselves include Bolts to work without running into “Include of non-modular header inside framework module” compilation errors.

The problem here was that there were dependencies included directly in the .h file instead of in the .m files (see here: http://stackoverflow.com/questions/28552500/xcode6-receiving-error-include-of-non-modular-header-inside-framework-module).

Instead these were moved to use the proper @class and @protocol definitions in the headers and only including the actual file in the .m file. This removes the circular dependency issues so that the Objective-C compiler can properly make everything work in projects that include sub-dependencies (ie: include a framework which it itself includes the Bolts library)