### PR TITLE
Fix disposing of CancellationTokenSource with registrations.

### DIFF
--- a/Bolts/Common/BFCancellationToken.m
+++ b/Bolts/Common/BFCancellationToken.m
@@ -124,11 +124,9 @@
         if (self.disposed) {
             return;
         }
+        [self.registrations makeObjectsPerformSelector:@selector(dispose)];
+        self.registrations = nil;
         self.disposed = YES;
-        for (BFCancellationTokenRegistration *registration in self.registrations) {
-            [registration dispose];
-        }
-        [self.registrations removeAllObjects];
     }
 }
 

--- a/BoltsTests/CancellationTests.m
+++ b/BoltsTests/CancellationTests.m
@@ -79,4 +79,12 @@
     XCTAssertThrowsSpecificNamed(cts.token.cancellationRequested, NSException, NSInternalInconsistencyException);
 }
 
+- (void)testDisposeRegistrationBeforeCancellationToken {
+    BFCancellationTokenSource *cts = [BFCancellationTokenSource cancellationTokenSource];
+    BFCancellationTokenRegistration *registration = [cts.token registerCancellationObserverWithBlock:^{ }];
+
+    [cts dispose];
+    XCTAssertNoThrow([registration dispose]);
+}
+
 @end


### PR DESCRIPTION
If you have registered at least 1 registration for the cancellation token and trying to dispose it - it will crash,
as we are enforcing that the disposal of registration happens before the disposal of cancellation token source,
even in case of internal API usage.

- Add a test that fails
- Fix the test by moving the disposal setter to after the registration disposal.