### PR TITLE
Rename method to avoid clashing with `NSCoderMethods` category

### DIFF
--- a/Bolts/Common/Bolts.h
+++ b/Bolts/Common/Bolts.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  Returns the version of the Bolts Framework as an NSString.
  @returns The NSString representation of the current version.
  */
-+ (NSString *)version;
++ (NSString *)frameworkVersion;
 
 @end
 

--- a/Bolts/Common/Bolts.m
+++ b/Bolts/Common/Bolts.m
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation Bolts
 
-+ (NSString *)version {
++ (NSString *)frameworkVersion {
     return BOLTS_VERSION;
 }
 


### PR DESCRIPTION
`NSCoderMethods` defines the `+version` as a category on `NSObject`, and so does `Bolts.m`. Enable `-Woverriding-method-mismatch` to see this warning.

This pr renames the `+version` method to `+frameworkVersion` to avoid conflicts.