### PR TITLE
Add no-side-effects version of navigateToAppLink:error: and navigate:

### DIFF
--- a/Bolts/iOS/BFAppLinkNavigation.h
+++ b/Bolts/iOS/BFAppLinkNavigation.h
@@ -57,6 +57,12 @@ typedef NS_ENUM(NSInteger, BFAppLinkNavigationType) {
                                extras:(NSDictionary *)extras
                           appLinkData:(NSDictionary *)appLinkData;
 
+/*!
+ Creates an NSDictionary with the correct format for iOS callback URLs,
+ to be used as 'appLinkData' argument in the call to navigationWithAppLink:extras:appLinkData:
+ */
++ (NSDictionary *)callbackAppLinkDataForAppWithName:(NSString *)appName url:(NSString *)url;
+
 /*! Performs the navigation */
 - (BFAppLinkNavigationType)navigate:(NSError **)error;
 
@@ -68,6 +74,20 @@ typedef NS_ENUM(NSInteger, BFAppLinkNavigationType) {
 
 /*! Navigates to a BFAppLink and returns whether it opened in-app or in-browser */
 + (BFAppLinkNavigationType)navigateToAppLink:(BFAppLink *)link error:(NSError **)error;
+
+/*!
+ Returns a BFAppLinkNavigationType based on a BFAppLink.
+ It's essentially a no-side-effect version of navigateToAppLink:error:,
+ allowing apps to determine flow based on the link type (e.g. open an
+ internal web view instead of going straight to the browser for regular links.)
+ */
++ (BFAppLinkNavigationType)navigationTypeForLink:(BFAppLink *)link;
+
+/*!
+ Return navigation type for current instance.
+ No-side-effect version of navigate:
+ */
+- (BFAppLinkNavigationType)navigationType;
 
 /*! Navigates to a URL (an asynchronous action) and returns a BFNavigationType */
 + (BFTask *)navigateToURLInBackground:(NSURL *)destination;

--- a/BoltsTestUI/BoltsTestUI-Info.plist
+++ b/BoltsTestUI/BoltsTestUI-Info.plist
@@ -39,6 +39,10 @@
 			</array>
 		</dict>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>bolts</string>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/BoltsTests/AppLinkTests.m
+++ b/BoltsTests/AppLinkTests.m
@@ -756,6 +756,19 @@ static NSMutableArray *openedUrls;
 
 #pragma mark App link navigation
 
+- (void)testSimpleAppLinkNavigationLookup {
+    BFAppLinkTarget *target = [BFAppLinkTarget appLinkTargetWithURL:[NSURL URLWithString:@"bolts://"]
+                                                         appStoreId:@"12345"
+                                                            appName:@"Bolts"];
+    BFAppLink *appLink = [BFAppLink appLinkWithSourceURL:[NSURL URLWithString:@"http://www.example.com/path"]
+                                                 targets:@[target]
+                                                  webURL:[NSURL URLWithString:@"http://www.example.com/path"]];
+    BFAppLinkNavigationType navigationType = [BFAppLinkNavigation navigationTypeForLink:appLink];
+
+    XCTAssertEqual(navigationType, BFAppLinkNavigationTypeApp);
+    XCTAssertEqual((NSUInteger)0, openedUrls.count); // no side effects
+}
+
 - (void)testSimpleAppLinkNavigation {
     BFAppLinkTarget *target = [BFAppLinkTarget appLinkTargetWithURL:[NSURL URLWithString:@"bolts://"]
                                                          appStoreId:@"12345"


### PR DESCRIPTION
_Rehash of #26_

### Summary

- Allows app to know the type of navigation that would result of calling `BFAppLinkNavigation`'s `+navigateToAppLink:error:` or `-navigate:` without having any side effects (i.e. no navigation)
- Also adds a test to ensure same output as `+navigateToAppLink:error:` without the side effects.

### Motivation

Relying on `-navigate:` completely hands off app behavior to Bolts. These no-side-effects functions allow apps to know what behavior Bolts is going to adopt with a given `BFAppLink`.

A developer might want to:

- completely hand off behavior if it's an AppLink with eligible targets or;
- use one of their own web views if it's just a regular link or a link that cannot be handled by any installed apps.