### PR TITLE
Unbreak build framework script.

### DIFF
--- a/Bolts/iOS/BFAppLinkNavigation.m
+++ b/Bolts/iOS/BFAppLinkNavigation.m
@@ -8,7 +8,7 @@
  *
  */
 
-#import <UIKit/UIKit.h>
+#import "BFAppLinkNavigation.h"
 
 #import <Bolts/Bolts.h>
 

--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -233,5 +233,4 @@ fi
 # Done
 #
 
-progress_message "Framework version info:" `perl -pe "s/.*@//" < $BOLTS_SRC/Bolts/Common/BoltsVersion.h`
 common_success


### PR DESCRIPTION
No more BoltsVersion header, thus this line fails and returns non-zero code.