### PR TITLE
Fix potential spurious thread wakeup.

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -499,7 +499,9 @@ NSString *const BFTaskMultipleExceptionsUserInfoKey = @"exceptions";
         }
         [self.condition lock];
     }
-    [self.condition wait];
+    while (!self.completed) {
+        [self.condition wait];
+    }
     [self.condition unlock];
 }
 


### PR DESCRIPTION
Getter for `self.completed` is protected with a `@synchronized` call, so this should be thread-safe to call like that in a loop.

Superseds #135 and fixes #134.