### PR TITLE
Fix potential deadlock in waitUntilFinished.

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -523,7 +523,9 @@ NSString *const BFTaskMultipleExceptionsUserInfoKey = @"exceptions";
         }
         [self.condition lock];
     }
-    while (!self.completed) {
+    // TODO: (nlutsenko) Restructure this to use Bolts-Swift thread access synchronization architecture
+    // In the meantime, it's absolutely safe to get `_completed` aka an ivar, as long as it's a `BOOL` aka less than word size.
+    while (!_completed) {
         [self.condition wait];
     }
     [self.condition unlock];


### PR DESCRIPTION
Surfaced via running tests on Parse framework many times and dead-locking, due to different lock order.