### PR TITLE
Fix method name collisions in Swift 3.0.

### DIFF
--- a/Bolts/Common/BFTask.h
+++ b/Bolts/Common/BFTask.h
@@ -26,7 +26,7 @@ extern NSInteger const kBFMultipleErrorsError;
 
 /*!
  An exception that is thrown if there was multiple exceptions on <BFTask taskForCompletionOfAllTasks:>.
- 
+
  @deprecated `BFTask` exception handling is deprecated and will be removed in a future release.
  */
 extern NSString *const BFTaskMultipleExceptionsException
@@ -41,7 +41,7 @@ extern NSString *const BFTaskMultipleErrorsUserInfoKey;
 /*!
  An error userInfo key used if there were multiple exceptions on <BFTask taskForCompletionOfAllTasks:>.
  Value type is `NSArray<NSException *> *`.
- 
+
  @deprecated `BFTask` exception handling is deprecated and will be removed in a future release.
  */
 extern NSString *const BFTaskMultipleExceptionsUserInfoKey
@@ -77,7 +77,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask<ResultType> *t);
 /*!
  Creates a task that is already completed with the given exception.
  @param exception The exception for the task.
- 
+
  @deprecated `BFTask` exception handling is deprecated and will be removed in a future release.
  */
 + (instancetype)taskWithException:(NSException *)exception
@@ -105,7 +105,7 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
 
 /*!
  Returns a task that will be completed once there is at least one successful task.
- The first task to successuly complete will set the result, all other tasks results are 
+ The first task to successuly complete will set the result, all other tasks results are
  ignored.
  @param tasks An `NSArray` of the tasks to use as an input.
  */
@@ -184,7 +184,7 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (BFTask *)continueWithBlock:(BFContinuationBlock)block;
+- (BFTask *)continueWithBlock:(BFContinuationBlock)block NS_SWIFT_NAME(continueWith(block:));
 
 /*!
  Enqueues the given block to be run once this task is complete.
@@ -198,7 +198,8 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (BFTask *)continueWithBlock:(BFContinuationBlock)block cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+- (BFTask *)continueWithBlock:(BFContinuationBlock)block
+            cancellationToken:(nullable BFCancellationToken *)cancellationToken NS_SWIFT_NAME(continueWith(block:cancellationToken:));
 
 /*!
  Enqueues the given block to be run once this task is complete.
@@ -209,7 +210,9 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (BFTask *)continueWithExecutor:(BFExecutor *)executor withBlock:(BFContinuationBlock)block;
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor
+                       withBlock:(BFContinuationBlock)block NS_SWIFT_NAME(continueWith(executor:block:));
+
 /*!
  Enqueues the given block to be run once this task is complete.
  @param executor A BFExecutor responsible for determining how the
@@ -222,7 +225,8 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  */
 - (BFTask *)continueWithExecutor:(BFExecutor *)executor
                            block:(BFContinuationBlock)block
-               cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+               cancellationToken:(nullable BFCancellationToken *)cancellationToken
+NS_SWIFT_NAME(continueWith(executor:block:cancellationToken:));
 
 /*!
  Identical to continueWithBlock:, except that the block is only run
@@ -234,7 +238,7 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (BFTask *)continueWithSuccessBlock:(BFContinuationBlock)block;
+- (BFTask *)continueWithSuccessBlock:(BFContinuationBlock)block NS_SWIFT_NAME(continueOnSuccessWith(block:));
 
 /*!
  Identical to continueWithBlock:, except that the block is only run
@@ -247,7 +251,9 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (BFTask *)continueWithSuccessBlock:(BFContinuationBlock)block cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+- (BFTask *)continueWithSuccessBlock:(BFContinuationBlock)block
+                   cancellationToken:(nullable BFCancellationToken *)cancellationToken
+NS_SWIFT_NAME(continueOnSuccessWith(block:cancellationToken:));
 
 /*!
  Identical to continueWithExecutor:withBlock:, except that the block
@@ -261,7 +267,8 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (BFTask *)continueWithExecutor:(BFExecutor *)executor withSuccessBlock:(BFContinuationBlock)block;
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor
+                withSuccessBlock:(BFContinuationBlock)block NS_SWIFT_NAME(continueOnSuccessWith(executor:block:));
 
 /*!
  Identical to continueWithExecutor:withBlock:, except that the block
@@ -278,7 +285,8 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  */
 - (BFTask *)continueWithExecutor:(BFExecutor *)executor
                     successBlock:(BFContinuationBlock)block
-               cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+               cancellationToken:(nullable BFCancellationToken *)cancellationToken
+NS_SWIFT_NAME(continueOnSuccessWith(executor:block:cancellationToken:));
 
 /*!
  Waits until this operation is completed.

--- a/Bolts/Common/BFTaskCompletionSource.h
+++ b/Bolts/Common/BFTaskCompletionSource.h
@@ -36,14 +36,14 @@ NS_ASSUME_NONNULL_BEGIN
  Attempting to set this for a completed task will raise an exception.
  @param result The result of the task.
  */
-- (void)setResult:(nullable ResultType)result;
+- (void)setResult:(nullable ResultType)result NS_SWIFT_NAME(set(result:));
 
 /*!
  Completes the task by setting the error.
  Attempting to set this for a completed task will raise an exception.
  @param error The error for the task.
  */
-- (void)setError:(NSError *)error;
+- (void)setError:(NSError *)error NS_SWIFT_NAME(set(error:));
 
 /*!
  Completes the task by setting an exception.
@@ -65,14 +65,14 @@ __attribute__((deprecated("`BFTask` exception handling is deprecated and will be
  Sets the result of the task if it wasn't already completed.
  @returns whether the new value was set.
  */
-- (BOOL)trySetResult:(nullable ResultType)result;
+- (BOOL)trySetResult:(nullable ResultType)result NS_SWIFT_NAME(trySet(result:));
 
 /*!
  Sets the error of the task if it wasn't already completed.
  @param error The error for the task.
  @returns whether the new value was set.
  */
-- (BOOL)trySetError:(NSError *)error;
+- (BOOL)trySetError:(NSError *)error NS_SWIFT_NAME(trySet(error:));
 
 /*!
  Sets the exception of the task if it wasn't already completed.

--- a/Bolts/Common/BFTaskCompletionSource.h
+++ b/Bolts/Common/BFTaskCompletionSource.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class BFTask<ResultType>;
+@class BFTask<__covariant ResultType>;
 
 /*!
  A BFTaskCompletionSource represents the producer side of tasks.


### PR DESCRIPTION
This fixes some of the method name collisions when importing Bolts-ObjC into Swift 3.0.
Be aware - the naming is heavily inspired by Bolts-Swift to ease the transfer for any projects using Bolts-ObjC in Swift.

Fixes #276.