### PR TITLE
Blocks should have void as argument if it accepts no arguments

### DIFF
--- a/Bolts/Common/BFCancellationToken.h
+++ b/Bolts/Common/BFCancellationToken.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  A block that will be called when a token is cancelled.
  */
-typedef void(^BFCancellationBlock)();
+typedef void(^BFCancellationBlock)(void);
 
 /*!
  The consumer view of a CancellationToken.

--- a/Bolts/Common/BFExecutor.h
+++ b/Bolts/Common/BFExecutor.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  Returns a new executor that uses the given block to execute continuations.
  @param block The block to use.
  */
-+ (instancetype)executorWithBlock:(void(^)(void(^block)()))block;
++ (instancetype)executorWithBlock:(void(^)(void(^block)(void)))block;
 
 /*!
  Returns a new executor that runs continuations on the given queue.
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
  Runs the given block using this executor's particular strategy.
  @param block The block to execute.
  */
-- (void)execute:(void(^)())block;
+- (void)execute:(void(^)(void))block;
 
 @end
 

--- a/Bolts/Common/BFTask.h
+++ b/Bolts/Common/BFTask.h
@@ -111,7 +111,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask<ResultType> *t);
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-+ (instancetype)taskFromExecutor:(BFExecutor *)executor withBlock:(nullable id (^)())block;
++ (instancetype)taskFromExecutor:(BFExecutor *)executor withBlock:(nullable id (^)(void))block;
 
 // Properties that will be set on the task once it is completed.
 

--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -223,7 +223,7 @@ NSString *const BFTaskMultipleErrorsUserInfoKey = @"errors";
     return tcs.task;
 }
 
-+ (instancetype)taskFromExecutor:(BFExecutor *)executor withBlock:(nullable id (^)())block {
++ (instancetype)taskFromExecutor:(BFExecutor *)executor withBlock:(nullable id (^)(void))block {
     return [[self taskWithResult:nil] continueWithExecutor:executor withBlock:^id(BFTask *task) {
         return block();
     }];
@@ -303,7 +303,7 @@ NSString *const BFTaskMultipleErrorsUserInfoKey = @"errors";
         [self.condition lock];
         [self.condition broadcast];
         [self.condition unlock];
-        for (void (^callback)() in self.callbacks) {
+        for (void (^callback)(void) in self.callbacks) {
             callback();
         }
         [self.callbacks removeAllObjects];


### PR DESCRIPTION
Declaring no arguments leads to block accepting any number of arguments
New warning introduced in Xcode 9