### PR TITLE
Fix Xcode analyze warning

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -56,7 +56,7 @@ NSString *const BFTaskMultipleErrorsUserInfoKey = @"errors";
     return self;
 }
 
-- (instancetype)initWithResult:(id)result {
+- (instancetype)initWithResult:(nullable id)result {
     self = [super init];
     if (!self) return self;
 


### PR DESCRIPTION
Below analyze hints can be found:
```
BFTask.m:89:12: nil passed to a callee that requires a non-null 1st parameter.

...
return [[self alloc] initWithResult:result];
```

This PR fix the analyze warning. Please check if the diff makes any sense.