### PR TITLE
Fix completed var thread safety problem

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -424,13 +424,11 @@ NSString *const BFTaskMultipleErrorsUserInfoKey = @"errors";
             return;
         }
         [self.condition lock];
+        while (!self.completed) {
+            [self.condition wait];
+        }
+        [self.condition unlock];
     }
-    // TODO: (nlutsenko) Restructure this to use Bolts-Swift thread access synchronization architecture
-    // In the meantime, it's absolutely safe to get `_completed` aka an ivar, as long as it's a `BOOL` aka less than word size.
-    while (!_completed) {
-        [self.condition wait];
-    }
-    [self.condition unlock];
 }
 
 #pragma mark - NSObject


### PR DESCRIPTION
Hi,

I've faced racing condition while using Bolts in our Apps, same issue reported before https://github.com/BoltsFramework/Bolts-ObjC/issues/302
Hot fix is to ensure locking the `completed` variable, however I don't know why wasn't it already in the lock block (deadlock?)? This is why I'm submitting this PR to ensure that the server tests will not fail since I'm unable to run tests locally (will figure this out).
I'd suggest handling thread safety for `BFTask` in an easier-to-read way than locks, what do you think? `GCD` for example, `sync_barrier`?

Updates: I've just seen https://github.com/BoltsFramework/Bolts-ObjC/pull/303 👍