### PR TITLE
Remove unnecessary podspec source_files

### DIFF
--- a/Bolts.podspec
+++ b/Bolts.podspec
@@ -20,17 +20,8 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.subspec 'Tasks' do |ss|
-    ss.ios.source_files = 'Bolts/Common/*.[hm]'
-    ss.ios.public_header_files = 'Bolts/Common/*.h'
-
-    ss.osx.source_files = 'Bolts/Common/*.[hm]'
-    ss.osx.public_header_files = 'Bolts/Common/*.h'
-
-    ss.watchos.source_files = 'Bolts/Common/*.[hm]'
-    ss.watchos.public_header_files = 'Bolts/Common/*.h'
-
-    ss.tvos.source_files = 'Bolts/Common/*.[hm]'
-    ss.tvos.public_header_files = 'Bolts/Common/*.h'
+    ss.source_files = 'Bolts/Common/*.[hm]'
+    ss.public_header_files = 'Bolts/Common/*.h'
   end
 
   s.subspec 'AppLinks' do |ss|
@@ -39,8 +30,5 @@ Pod::Spec.new do |s|
 
     ss.ios.source_files = 'Bolts/iOS/**/*.[hm]'
     ss.ios.public_header_files = 'Bolts/iOS/*.h'
-    ss.osx.source_files = ''
-    ss.watchos.source_files = ''
-    ss.tvos.source_files = ''
   end
 end


### PR DESCRIPTION
There are 2 changes here:

1. Remove the per platform source_files and public_header_files globs
from the Tasks subspec because they are the same for all platforms
2. Remove the empty source_files definitions from the AppLinks subspec.
This subspec only supports iOS so these are unnecessary