### PR TITLE
fix facebook build on xcode 10 using carthage

### DIFF
--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -120,7 +120,6 @@ function xcode_build_target() {
     -configuration "${2}" \
     SYMROOT="$BOLTS_BUILD" \
     CURRENT_PROJECT_VERSION="$BOLTS_VERSION_FULL" \
-    clean build \
     || die "Xcode build failed for platform: ${1}."
 }
 


### PR DESCRIPTION
This pr fixes compiling `facebook-ios-sdk` and `facebook-swift-sdk` with latest xcode 10 using carthage by implementing the fixes described in https://github.com/facebook/facebook-sdk-swift/issues/246

ps: to be clear, when building Bolts directly using Carthage there was no issues at all, including compiling on latest beta 6, it is just when compiling either `facebook-ios-sdk` or `facebook-swift-sdk` that the problem arises